### PR TITLE
Adding distributed tracing library to push traces to Zipkin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,32 +35,14 @@
       <organizationUrl>https://www.vmware.com/</organizationUrl>
     </developer>
     <developer>
-      <name>Tadaya Tsuyukubo</name>
-      <email>ttsuyukubo@vmware.com</email>
+      <name>Pieter Noordhuis</name>
+      <email>pnoordhuis@vmware.com</email>
       <organization>VMware</organization>
       <organizationUrl>https://www.vmware.com/</organizationUrl>
     </developer>
     <developer>
-      <name>Sufian Dar</name>
-      <email>dars@vmware.com</email>
-      <organization>VMware</organization>
-      <organizationUrl>https://www.vmware.com/</organizationUrl>
-    </developer>
-    <developer>
-      <name>Asaf Kariv</name>
-      <email>kariva@vmware.com</email>
-      <organization>VMware</organization>
-      <organizationUrl>https://www.vmware.com/</organizationUrl>
-    </developer>
-    <developer>
-      <name>Gurudutt Belur</name>
-      <email>gbelur@vmware.com</email>
-      <organization>VMware</organization>
-      <organizationUrl>https://www.vmware.com/</organizationUrl>
-    </developer>
-    <developer>
-      <name>Vamsi Krishna Brahmajosyula</name>
-      <email>vbrahmajosyula@vmware.com</email>
+      <name>Mihnea Olteanu</name>
+      <email>molteanu@vmware.com</email>
       <organization>VMware</organization>
       <organizationUrl>https://www.vmware.com/</organizationUrl>
     </developer>
@@ -80,6 +62,7 @@
     <module>xenon-swagger</module>
     <module>xenon-loader-test</module>
     <module>xenon-dns</module>
+    <module>xenon-zipkin</module>
   </modules>
 
   <properties>
@@ -132,6 +115,7 @@
         <module>xenon-dns</module>
         <module>xenon-websocket-test</module>
         <module>xenon-client</module>
+        <module>xenon-zipkin</module>
       </modules>
       <activation>
         <activeByDefault>true</activeByDefault>

--- a/xenon-zipkin/pom.xml
+++ b/xenon-zipkin/pom.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.vmware.xenon</groupId>
+        <artifactId>xenon-parent</artifactId>
+        <version>0.9.7-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>xenon-zipkin</artifactId>
+
+    <properties>
+        <brave.version>3.11.0</brave.version>
+        <gson.version>2.7</gson.version>
+        <guava.version>18.0</guava.version>
+        <springboot.version>1.4.1.RELEASE</springboot.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-core</artifactId>
+            <version>${brave.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-spancollector-http</artifactId>
+            <version>${brave.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-http</artifactId>
+            <version>${brave.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.zipkin.brave</groupId>
+            <artifactId>brave-spring-resttemplate-interceptors</artifactId>
+            <version>${brave.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${springboot.version}</version>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>${gson.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>xenon-common</artifactId>
+            <version>${project.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/Tracer.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/Tracer.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing;
+
+import java.util.Map;
+
+import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.IdConversion;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.BraveHttpHeaders;
+import com.github.kristofa.brave.spring.BraveClientHttpRequestInterceptor;
+import com.google.gson.Gson;
+
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpRequestInterceptor;
+
+import com.vmware.xenon.tracing.spring.XenonClientAsyncHttpRequestInterceptor;
+import com.vmware.xenon.tracing.zipkin.ZipkinTracer;
+
+/**
+ * Tracer class which will help tracing an application or a stack (within an application).
+ */
+public class Tracer {
+
+    private ZipkinTracer zipkinTracer;
+    private String appStackName;
+    private boolean startTracing;
+
+    public static synchronized Tracer getTracer() {
+        return getTracer(true);
+    }
+
+    public static synchronized Tracer getTracer(String tracerName) {
+        return getTracer(tracerName, true);
+    }
+
+    public static synchronized Tracer getTracer(boolean startTracing) {
+        return getTracer(null, startTracing);
+    }
+
+    public static synchronized Tracer getTracer(String tracerName, boolean startTracing) {
+        return new Tracer(tracerName, startTracing);
+    }
+
+    private Tracer(String appStackName, boolean startTracing) {
+        this.appStackName = appStackName;
+        this.startTracing = startTracing;
+    }
+
+    public ZipkinTracer getServiceTracer() {
+        //Lazy initialize the brave tracer
+        if (this.zipkinTracer == null) {
+            this.zipkinTracer = ZipkinTracer.getTracer(this.appStackName, this.startTracing);
+        }
+        return this.zipkinTracer;
+    }
+
+    public void submitAnnotation(String key, String value) {
+        getServiceTracer().submitAnnotation(key, value);
+    }
+
+    public SpanId startLocalSpan(String component, String operation) {
+        return getServiceTracer().startLocalSpan(component, operation);
+    }
+
+    public void endLocalSpan(SpanId spanId) {
+        getServiceTracer().endLocalSpan(spanId);
+    }
+
+    public String startServerSpanAndGenerateContextId(Map<String, String> httpHeaders) {
+        String traceId = httpHeaders.get(BraveHttpHeaders.TraceId.getName().toLowerCase());
+        String spanId = httpHeaders.get(BraveHttpHeaders.SpanId.getName().toLowerCase());
+        String parentSpanId = httpHeaders
+                .get(BraveHttpHeaders.ParentSpanId.getName().toLowerCase());
+        String sampled = httpHeaders.get(BraveHttpHeaders.Sampled.getName().toLowerCase());
+        boolean success = startServerSpan(traceId, spanId, parentSpanId, sampled);
+        if (success) {
+            return generateContextJson(traceId, spanId, parentSpanId, sampled, generateId());
+        } else {
+            return null;
+        }
+    }
+
+    private static class Context {
+        private String traceId;
+        private String spanId;
+        private String parentSpanId;
+        private String sampled;
+        private String contextId;
+
+        public Context(String traceId, String spanId, String parentSpanId, String sampled,
+                String contextId) {
+            this.traceId = traceId;
+            this.spanId = spanId;
+            this.parentSpanId = parentSpanId;
+            this.sampled = sampled;
+            this.contextId = contextId;
+        }
+
+        public String getTraceId() {
+            return this.traceId;
+        }
+
+        public String getSpanId() {
+            return this.spanId;
+        }
+
+        public String getParentSpanId() {
+            return this.parentSpanId;
+        }
+
+        public String getSampled() {
+            return this.sampled;
+        }
+
+        public String getContextId() {
+            return this.contextId;
+        }
+    }
+
+    private String generateContextJson(String traceId, String spanId, String parentSpanId,
+            String sampled, String contextId) {
+        Gson gson = new Gson();
+        return gson.toJson(new Context(traceId, spanId, parentSpanId, sampled,
+                contextId));
+    }
+
+    private String generateId() {
+        return String.valueOf(System.nanoTime());
+    }
+
+    public boolean startServerSpan(String traceIdStr, String spanIdStr, String parentSpanIdStr,
+            String sampledStr) {
+        if (traceIdStr != null && spanIdStr != null && sampledStr != null) {
+            long traceId = IdConversion.convertToLong(traceIdStr);
+            long eSpanId = IdConversion.convertToLong(spanIdStr);
+            Long parentSpanId = null;
+            if (parentSpanIdStr != null) {
+                parentSpanId = IdConversion.convertToLong(parentSpanIdStr);
+            }
+            String name = sampledStr;
+            getServiceTracer().startServerSpan(traceId, eSpanId, parentSpanId, name);
+            return true;
+        }
+        return false;
+    }
+
+    public void endServerSpan() {
+        getServiceTracer().endServerSpan();
+    }
+
+    public void startClientSpan() {
+        getServiceTracer().startClientSpan();
+    }
+
+    public void endClientSpan() {
+        getServiceTracer().endClientSpan();
+    }
+
+    public AsyncClientHttpRequestInterceptor getAsyncHttpRequestInterceptor() {
+        return new XenonClientAsyncHttpRequestInterceptor(
+                new ClientRequestInterceptor(getServiceTracer().getClientTracer()),
+                new ClientResponseInterceptor(getServiceTracer().getClientTracer()),
+                getServiceTracer().getSpanNameProvider());
+    }
+
+    public ClientHttpRequestInterceptor getHttpRequestInterceptor() {
+        return new BraveClientHttpRequestInterceptor(
+                new ClientRequestInterceptor(getServiceTracer().getClientTracer()),
+                new ClientResponseInterceptor(getServiceTracer().getClientTracer()),
+                getServiceTracer().getSpanNameProvider());
+    }
+
+    public boolean startTracing() {
+        return getServiceTracer().startTrackingSpans();
+    }
+
+    public boolean stopTracing() {
+        return getServiceTracer().stopTrackingSpans();
+    }
+
+}

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/spring/XenonClientAsyncHttpRequestInterceptor.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/spring/XenonClientAsyncHttpRequestInterceptor.java
@@ -1,0 +1,172 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing.spring;
+
+import java.io.IOException;
+import java.net.URI;
+
+import com.github.kristofa.brave.ClientRequestInterceptor;
+import com.github.kristofa.brave.ClientResponseInterceptor;
+import com.github.kristofa.brave.NoAnnotationsClientResponseAdapter;
+import com.github.kristofa.brave.http.HttpClientRequest;
+import com.github.kristofa.brave.http.HttpClientRequestAdapter;
+import com.github.kristofa.brave.http.HttpClientResponseAdapter;
+import com.github.kristofa.brave.http.HttpResponse;
+import com.github.kristofa.brave.http.SpanNameProvider;
+
+import org.springframework.http.HttpRequest;
+import org.springframework.http.client.AsyncClientHttpRequestExecution;
+import org.springframework.http.client.AsyncClientHttpRequestInterceptor;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.util.concurrent.FailureCallback;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.SuccessCallback;
+
+/**
+ * Http Request interceptors for Spring based services which will submit spans to Zipkin.
+ */
+public class XenonClientAsyncHttpRequestInterceptor implements AsyncClientHttpRequestInterceptor {
+
+    private final ClientRequestInterceptor requestInterceptor;
+    private final ClientResponseInterceptor responseInterceptor;
+    private final SpanNameProvider spanNameProvider;
+
+    /**
+     * Constructor.
+     *
+     * @param requestInterceptor request interceptor
+     * @param responseInterceptor response interceptor
+     * @param spanNameProvider span name provider
+     */
+    public XenonClientAsyncHttpRequestInterceptor(final ClientRequestInterceptor requestInterceptor,
+            final ClientResponseInterceptor responseInterceptor,
+            final SpanNameProvider spanNameProvider) {
+        this.requestInterceptor = requestInterceptor;
+        this.responseInterceptor = responseInterceptor;
+        this.spanNameProvider = spanNameProvider;
+    }
+
+    @Override
+    public ListenableFuture<ClientHttpResponse> intercept(HttpRequest request, byte[] body,
+            AsyncClientHttpRequestExecution execution)
+            throws IOException {
+
+        this.requestInterceptor
+                .handle(new HttpClientRequestAdapter(new SpringHttpClientRequest(request),
+                        this.spanNameProvider));
+
+        ListenableFuture<ClientHttpResponse> future = execution.executeAsync(request, body);
+        future.addCallback(
+                new HttpResponseSuccessCallBack<ClientHttpResponse>(this.responseInterceptor),
+                new HttpResponseFailureCallBack(this.responseInterceptor));
+        return future;
+    }
+
+    /**
+     * Wrapper class for Success Callback.
+     * @param <C>
+     */
+    static class HttpResponseSuccessCallBack<C> implements SuccessCallback<ClientHttpResponse> {
+        private ClientResponseInterceptor responseInterceptor;
+
+        public HttpResponseSuccessCallBack(ClientResponseInterceptor responseInterceptor) {
+            this.responseInterceptor = responseInterceptor;
+        }
+
+        @Override
+        public void onSuccess(ClientHttpResponse resp) {
+            try {
+                this.responseInterceptor
+                        .handle(new HttpClientResponseAdapter(
+                                new SpringHttpResponse(resp.getRawStatusCode())));
+            } catch (RuntimeException | IOException up) {
+                // Ignore the failure of not being able to get the status code from the response;
+                // let the calling code find out themselves
+                this.responseInterceptor.handle(NoAnnotationsClientResponseAdapter.getInstance());
+            }
+        }
+    }
+
+    /**
+     * Wrapper class for Failure Callback.
+     */
+    static class HttpResponseFailureCallBack implements FailureCallback {
+        private ClientResponseInterceptor responseInterceptor;
+
+        public HttpResponseFailureCallBack(ClientResponseInterceptor responseInterceptor) {
+            this.responseInterceptor = responseInterceptor;
+        }
+
+        @Override
+        public void onFailure(Throwable ex) {
+            // process error
+            this.responseInterceptor.handle(NoAnnotationsClientResponseAdapter.getInstance());
+        }
+    }
+
+    /**
+     * Wrapper class.
+     */
+    static class SpringHttpClientRequest implements HttpClientRequest {
+
+        private final HttpRequest request;
+
+        /**
+         * Constructor.
+         *
+         * @param request request
+         */
+        SpringHttpClientRequest(final HttpRequest request) {
+            this.request = request;
+        }
+
+        @Override
+        public void addHeader(final String header, final String value) {
+            this.request.getHeaders().add(header, value);
+        }
+
+        @Override
+        public URI getUri() {
+            return this.request.getURI();
+        }
+
+        @Override
+        public String getHttpMethod() {
+            return this.request.getMethod().name();
+        }
+    }
+
+    /**
+     * Wrapper class.
+     */
+    static class SpringHttpResponse implements HttpResponse {
+
+        private final int status;
+
+        /**
+         * Constructor.
+         *
+         * @param status status
+         */
+        SpringHttpResponse(final int status) {
+            this.status = status;
+        }
+
+        @Override
+        public int getHttpStatusCode() {
+            return this.status;
+        }
+    }
+}
+

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinConfig.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinConfig.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing.zipkin;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.logging.Logger;
+
+import com.github.kristofa.brave.BoundarySampler;
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.EmptySpanCollectorMetricsHandler;
+import com.github.kristofa.brave.InheritableServerClientAndLocalSpanState;
+import com.github.kristofa.brave.LoggingSpanCollector;
+import com.github.kristofa.brave.SpanCollector;
+import com.github.kristofa.brave.http.HttpSpanCollector;
+import com.google.common.base.CaseFormat;
+import com.twitter.zipkin.gen.Endpoint;
+
+/**
+ * This will read and configure the Zipkin settings - zipkin url, sampling rate & app/stack name.
+ * The values for these settings will be read from java system properties - tracer.appName,
+ * tracer.sampleRate & tracer.zipkinUrl. If those are not available then it will be read from
+ * environment variables - TRACER_APP_NAME, TRACER_SAMPLE_RATE & TRACER_ZIPKIN_URL. In case, even
+ * those are also, not available, then a No-Op Tracer will be returned.
+ */
+public class ZipkinConfig {
+
+    private static final Logger LOG = Logger.getLogger(ZipkinConfig.class.getName());
+    private static final String PARAM_TRACER_APP_NAME = "tracer.appName";
+    private static final String PARAM_TRACER_SAMPLE_RATE = "tracer.sampleRate";
+    private static final String PARAM_TRACER_ZIPKIN_URL = "tracer.zipkinUrl";
+    private static final String DEFAULT_APP_NAME = "service";
+    private static final float DEFAULT_SAMPLE_RATE = 1.0f;
+
+    private static float getSampleRate() {
+        float sampleRate;
+        String sampleRateStr = readParameter(PARAM_TRACER_SAMPLE_RATE);
+        if (sampleRateStr == null) {
+            sampleRate = DEFAULT_SAMPLE_RATE;
+        } else {
+            try {
+                sampleRate = Float.parseFloat(sampleRateStr);
+            } catch (NumberFormatException nfe) {
+                sampleRate = DEFAULT_SAMPLE_RATE;
+            }
+        }
+        return sampleRate;
+    }
+
+    private static String getZipkinUrl() {
+        return readParameter(PARAM_TRACER_ZIPKIN_URL);
+    }
+
+    private static String readParameter(String varName) {
+        String varValue = System.getProperty(varName);
+        if (varValue == null || varValue.isEmpty() || varValue
+                .equalsIgnoreCase("null")) {
+            String envVarName = CaseFormat.LOWER_CAMEL.to(CaseFormat.UPPER_UNDERSCORE, varName);
+            envVarName = envVarName.replaceAll("\\.", "_");
+            varValue = System.getenv(envVarName);
+        }
+        return varValue;
+    }
+
+    public static String getTracerName(String stackName) {
+        String appName = readParameter(PARAM_TRACER_APP_NAME);
+
+        if (appName == null) {
+            appName = DEFAULT_APP_NAME;
+        }
+
+        String hostName = "";
+        try {
+            hostName = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException e) {
+            e.printStackTrace();
+        }
+
+        if (stackName == null || stackName.isEmpty() || stackName
+                .equalsIgnoreCase("null")) {
+            return appName + "-" + hostName;
+        }
+        return appName + "-" + stackName + "-" + hostName;
+    }
+
+    public static Brave getBraveInstance(String tracerName) {
+        InheritableServerClientAndLocalSpanState state = new InheritableServerClientAndLocalSpanState(
+                Endpoint.create(tracerName, 0));
+        Brave.Builder builder = new Brave.Builder(state);
+
+        String zipkinUrl = getZipkinUrl();
+        SpanCollector spanCollector = null;
+        float rate = getSampleRate();
+        if (zipkinUrl == null) {
+            spanCollector = new LoggingSpanCollector();
+            rate = 0;
+            LOG.info(String.format("Initialized Tracer: [%s] as a Logger which wont sample",
+                    tracerName));
+        } else {
+            spanCollector = HttpSpanCollector.create(zipkinUrl,
+                    new EmptySpanCollectorMetricsHandler());
+            LOG.info(String.format(
+                    "Initialized Tracer: [%s] which will submit traces to [%s] and will sample at rate: [%s]",
+                    tracerName, zipkinUrl, rate));
+        }
+        builder.spanCollector(spanCollector)
+                .traceSampler(BoundarySampler.create(rate));
+        return builder.build();
+    }
+
+}

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinLocalSpanCache.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinLocalSpanCache.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing.zipkin;
+
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+import com.google.common.base.Optional;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.twitter.zipkin.gen.Span;
+
+/**
+ * Zipkin local span cache - this cache will be used to track the spans.
+ * It will keep the spans for 1 minute, and then the span will be removed from the cache.
+ * If a span is closed before 1 minute, it's removed anyway from the cache.
+ */
+public class ZipkinLocalSpanCache {
+    private static final long MAX_SIZE = 10000;
+    private static final long MAX_TIME_IN_MINUTES = 1;
+    private static final Logger LOG = Logger.getLogger(ZipkinLocalSpanCache.class.getName());
+    private final LoadingCache<CachedSpan, Optional<String>> cache;
+
+    public ZipkinLocalSpanCache() {
+        this.cache = CacheBuilder.newBuilder().maximumSize(MAX_SIZE)
+                .expireAfterWrite(MAX_TIME_IN_MINUTES, TimeUnit.MINUTES)
+                .build(new CacheLoader<CachedSpan, Optional<String>>() {
+                    @Override
+                    public Optional<String> load(CachedSpan span) {
+                        return Optional.fromNullable(getDefault(span));
+                    }
+
+                    private String getDefault(CachedSpan span) {
+                        return null;
+                    }
+                });
+    }
+
+    public String get(CachedSpan key) {
+        if (!this.cache.getUnchecked(key).isPresent()) {
+            return null;
+        }
+        return this.cache.getUnchecked(key).get();
+    }
+
+    public void clean() {
+        this.cache.invalidateAll();
+    }
+
+    public boolean isEmpty() {
+        return this.cache.size() == 0L;
+    }
+
+    public long size() {
+        return this.cache.size();
+    }
+
+    public void put(CachedSpan cachedSpan, String location) {
+        this.cache.put(cachedSpan, Optional.of(location));
+    }
+
+    public void remove(CachedSpan cachedSpan) {
+        this.cache.invalidate(cachedSpan);
+    }
+
+    public static class CachedSpan {
+        Span span;
+        private long traceId;
+        private long id;
+        private Long parentId;
+
+        CachedSpan(Span span) {
+            this.span = span;
+            if (span != null) {
+                this.traceId = span.getTrace_id();
+                this.id = span.getId();
+                this.parentId = span.getParent_id();
+            }
+        }
+
+        public Span getSpan() {
+            return this.span;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof CachedSpan)) {
+                return false;
+            }
+            CachedSpan that = (CachedSpan) o;
+            return (this.traceId == that.traceId && this.id == that.id
+                    && ((this.parentId != null && that.parentId != null) ?
+                    (this.parentId.longValue() == that.parentId.longValue()) :
+                    (this.parentId == null && that.parentId == null)));
+        }
+
+        @Override
+        public int hashCode() {
+            if (this.span == null) {
+                return 0;
+            }
+
+            final int prime = 31;
+            int result = 1;
+            result = result * prime + Long.hashCode(this.traceId);
+            result = result * prime + Long.hashCode(this.id);
+            if (this.parentId != null) {
+                result = result * prime + Long.hashCode(this.parentId);
+            }
+            return result;
+        }
+
+        @Override public String toString() {
+            return "{traceId=" + this.span.getTrace_id() + ", spanId=" + this.span.getId()
+                    + ", parentSpanId=" + this.span.getParent_id() + ", name=" + this.span.getName()
+                    + "}";
+        }
+
+    }
+
+    public ConcurrentMap<CachedSpan, Optional<String>> getEntries() {
+        return this.cache.asMap();
+    }
+}

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinLocalSpanTracker.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinLocalSpanTracker.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing.zipkin;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.SpanId;
+import com.twitter.zipkin.gen.Span;
+
+import com.vmware.xenon.tracing.zipkin.ZipkinLocalSpanCache.CachedSpan;
+
+/**
+ * Local Span Tracker for Asynchronous as well as Nested Spans.
+ */
+public class ZipkinLocalSpanTracker {
+    private Brave brave;
+    private volatile boolean isTraceRunning;
+
+    //To track what all spans are still to be closed while debugging
+    private ZipkinLocalSpanCache openedSpans;
+
+    // What all spans are marked to be closed, but could be waiting
+    // on nested spans to close before closing themselves.
+    private ZipkinLocalSpanCache closableSpans;
+
+    public ZipkinLocalSpanTracker(Brave brave) {
+        this.brave = brave;
+        this.openedSpans = new ZipkinLocalSpanCache();
+        this.closableSpans = new ZipkinLocalSpanCache();
+    }
+
+    public boolean isTraceRunning() {
+        return this.isTraceRunning;
+    }
+
+    public boolean startTracing() {
+        return (this.isTraceRunning = true);
+    }
+
+    public boolean stopTracing() {
+        this.openedSpans.clean();
+        this.closableSpans.clean();
+        return (this.isTraceRunning = false);
+    }
+
+    private void markSpanFinished(Span expectedSpan) {
+        this.brave.localTracer().finishSpan();
+    }
+
+    private Span readSpan() {
+        return this.brave.localSpanThreadBinder().getCurrentLocalSpan();
+    }
+
+    private void closeAllPossibleSpans() {
+        while (true) {
+            if (this.closableSpans.isEmpty()) {
+                break;
+            }
+            Span currentSpan = readSpan();
+            CachedSpan cachedSpan = new CachedSpan(currentSpan);
+            if (this.closableSpans.get(cachedSpan) == null) {
+                break;
+            }
+            this.closableSpans.remove(cachedSpan);
+            this.openedSpans.remove(cachedSpan);
+        }
+    }
+
+    public SpanId startLocalSpan(String component, String operation) {
+        if (!this.isTraceRunning) {
+            return null;
+        }
+        SpanId spanId = this.brave.localTracer().startNewSpan(component, operation);
+        if (spanId != null) {
+            CachedSpan cachedSpan = new CachedSpan(spanId.toSpan());
+            this.openedSpans.put(cachedSpan, component + "." + operation);
+        }
+        return spanId;
+    }
+
+    public void endLocalSpan(Span spanSent) {
+        if (!this.isTraceRunning) {
+            return;
+        }
+        CachedSpan cachedSpan = new CachedSpan(spanSent);
+        String openedSpanDetail = this.openedSpans.get(cachedSpan);
+        if (openedSpanDetail == null) {
+            openedSpanDetail = "Unknown";
+        }
+        this.closableSpans.put(cachedSpan, openedSpanDetail);
+        closeAllPossibleSpans();
+    }
+
+    public ZipkinLocalSpanCache getOpenedSpans() {
+        return this.openedSpans;
+    }
+
+    public ZipkinLocalSpanCache getClosableSpans() {
+        return this.closableSpans;
+    }
+}

--- a/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinTracer.java
+++ b/xenon-zipkin/src/main/java/com/vmware/xenon/tracing/zipkin/ZipkinTracer.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing.zipkin;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.github.kristofa.brave.Brave;
+import com.github.kristofa.brave.ClientTracer;
+import com.github.kristofa.brave.SpanId;
+import com.github.kristofa.brave.http.DefaultSpanNameProvider;
+import com.github.kristofa.brave.http.SpanNameProvider;
+
+/**
+ * Zipkin Tracer which will be used to submit traces to Zipkin. It will abstract
+ * the underlying mechanism to submit the traces to Zipkin. Currently its based on
+ * Openzipkin Brave libraries.
+ */
+public class ZipkinTracer {
+
+    private static Map<String, ZipkinTracer> tracers = new HashMap<>();
+
+    private ZipkinLocalSpanTracker localSpanTracker;
+    private final Brave brave;
+
+    private final String tracerName;
+
+    private ZipkinTracer(String tracerName) {
+        this.tracerName = tracerName;
+        this.brave = ZipkinConfig.getBraveInstance(this.tracerName);
+        this.localSpanTracker = new ZipkinLocalSpanTracker(this.brave);
+    }
+
+    public static synchronized ZipkinTracer getTracer() {
+        return getTracer(null, true);
+    }
+
+    public static synchronized ZipkinTracer getTracer(String stackName) {
+        return getTracer(stackName, true);
+    }
+
+    public static synchronized ZipkinTracer getTracer(String stackName, boolean startTracing) {
+        String tracerName = ZipkinConfig.getTracerName(stackName);
+
+        if (tracers.containsKey(tracerName)) {
+            return tracers.get(tracerName);
+        }
+        ZipkinTracer tracer = new ZipkinTracer(tracerName);
+        if (startTracing) {
+            tracer.startTrackingSpans();
+        }
+        tracers.put(tracerName, tracer);
+        return tracer;
+    }
+
+    public boolean startTrackingSpans() {
+        if (!this.localSpanTracker.isTraceRunning()) {
+            return this.localSpanTracker.startTracing();
+        }
+        return false;
+    }
+
+    public boolean stopTrackingSpans() {
+        return this.localSpanTracker.stopTracing();
+    }
+
+    public SpanId startLocalSpan(String component, String operation) {
+        return this.localSpanTracker.startLocalSpan(component, operation);
+    }
+
+    public void endLocalSpan(SpanId spanId) {
+        if (spanId == null) {
+            return;
+        }
+        this.localSpanTracker.endLocalSpan(spanId.toSpan());
+    }
+
+    public void startServerSpan(long traceId, long eSpanId, Long parentSpanId, String name) {
+        this.brave.serverTracer().setStateCurrentTrace(traceId, eSpanId, parentSpanId, name);
+        this.brave.serverTracer().setServerReceived();
+    }
+
+    public void startClientSpan() {
+        this.brave.clientTracer().setClientSent();
+    }
+
+    public void endClientSpan() {
+        this.brave.clientTracer().setClientReceived();
+    }
+
+    public void endServerSpan() {
+        this.brave.serverTracer().setServerSend();
+    }
+
+    public void submitAnnotation(String key, String value) {
+        if (key != null && value != null) {
+            this.brave.localTracer().submitBinaryAnnotation(key, value);
+        }
+    }
+
+    public SpanNameProvider getSpanNameProvider() {
+        return new DefaultSpanNameProvider();
+    }
+
+    public ClientTracer getClientTracer() {
+        return this.brave.clientTracer();
+    }
+
+    public ZipkinLocalSpanCache getOpenedSpans() {
+        return this.localSpanTracker.getOpenedSpans();
+    }
+
+    public ZipkinLocalSpanCache getClosableSpans() {
+        return this.localSpanTracker.getClosableSpans();
+    }
+
+    @Override
+    public String toString() {
+        return "ZipkinTracer{" +
+                "localSpanTracker=" + this.localSpanTracker +
+                ", brave=" + this.brave +
+                ", tracerName='" + this.tracerName + '\'' +
+                '}';
+    }
+
+}

--- a/xenon-zipkin/src/test/java/com/vmware/xenon/tracing/TestTracingHost.java
+++ b/xenon-zipkin/src/test/java/com/vmware/xenon/tracing/TestTracingHost.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing;
+
+import java.util.logging.Level;
+
+import com.github.kristofa.brave.SpanId;
+
+import com.vmware.xenon.common.Service.ServiceOption;
+import com.vmware.xenon.common.ServiceHost;
+import com.vmware.xenon.services.common.ExampleService;
+import com.vmware.xenon.services.common.ExampleTaskService;
+import com.vmware.xenon.services.common.LuceneDocumentIndexService;
+import com.vmware.xenon.services.common.RootNamespaceService;
+
+/**
+ * Our entry point, spawning a host that run/showcase examples we can play with.
+ */
+public class TestTracingHost extends ServiceHost {
+
+    private Tracer tracer = Tracer.getTracer();
+
+    public static void main(String[] args) throws Throwable {
+        TestTracingHost h = new TestTracingHost();
+        h.initialize(args);
+        LuceneDocumentIndexService documentIndexService = new LuceneDocumentIndexService();
+        documentIndexService.toggleOption(ServiceOption.INSTRUMENTATION, true);
+        h.setDocumentIndexingService(documentIndexService);
+        h.toggleDebuggingMode(true);
+        h.start();
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            h.log(Level.WARNING, "Host stopping ...");
+            h.stop();
+            h.log(Level.WARNING, "Host is stopped");
+        }));
+    }
+
+    public Tracer getTracer() {
+        return this.tracer;
+    }
+
+    @Override
+    public ServiceHost start() throws Throwable {
+        SpanId spanId = this.tracer.startLocalSpan(this.getClass().getName(), "start");
+        super.start();
+
+        // Start core services, must be done once
+        SpanId nestedSpanId = this.tracer
+                .startLocalSpan(this.getClass().getName(), "startDefaultCore");
+        startDefaultCoreServicesSynchronously();
+
+        // Start the root namespace service: this will list all available factory services for
+        // queries to the root (/)
+        super.startService(new RootNamespaceService());
+        this.tracer.endLocalSpan(nestedSpanId);
+
+        SpanId exampleSpanId = this.tracer
+                .startLocalSpan(this.getClass().getName(), "startExampleServices");
+        // Start example tutorial services
+        super.startFactory(new ExampleService());
+        super.startFactory(new ExampleTaskService());
+        this.tracer.endLocalSpan(exampleSpanId);
+        this.tracer.endLocalSpan(spanId);
+        return this;
+    }
+
+    @Override public void startDefaultCoreServicesSynchronously() throws Throwable {
+        SpanId spanId = this.tracer
+                .startLocalSpan(this.getClass().getName(), "startDefaultCoreServicesSynchronously");
+        super.startDefaultCoreServicesSynchronously();
+        this.tracer.endLocalSpan(spanId);
+    }
+}

--- a/xenon-zipkin/src/test/java/com/vmware/xenon/tracing/TracerTest.java
+++ b/xenon-zipkin/src/test/java/com/vmware/xenon/tracing/TracerTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2014-2015 VMware, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License.  You may obtain a copy of
+ * the License at http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, without warranties or
+ * conditions of any kind, EITHER EXPRESS OR IMPLIED.  See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+package com.vmware.xenon.tracing;
+
+import java.util.UUID;
+
+import junit.framework.TestCase;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+public class TracerTest extends TestCase {
+
+    private TestTracingHost launchService(TemporaryFolder tmpFolder) throws Throwable {
+        TestTracingHost h = new TestTracingHost();
+        String bindAddress = "127.0.0.1";
+        String hostId = UUID.randomUUID().toString();
+        String[] args = {
+                "--port=0",
+                "--sandbox=" + tmpFolder.getRoot().getAbsolutePath(),
+                "--bindAddress=" + bindAddress,
+                "--id=" + hostId
+        };
+        h.initialize(args);
+        h.start();
+        return h;
+    }
+
+    @Test
+    public void testNoSystemProperties() throws Throwable {
+        System.setProperty("tracer.appName", "");
+        System.setProperty("tracer.sampleRate", "");
+        System.setProperty("tracer.zipkinUrl", "");
+        TemporaryFolder tmpFolder = new TemporaryFolder();
+        tmpFolder.create();
+        TestTracingHost h = null;
+        try {
+            h = launchService(tmpFolder);
+            assertTrue(h.getTracer().getServiceTracer().getClosableSpans().size() == 0);
+            assertTrue(h.getTracer().getServiceTracer().getOpenedSpans().size() == 0);
+        } finally {
+            assertNotNull(h);
+            h.stop();
+            tmpFolder.delete();
+        }
+
+    }
+
+    @Test
+    public void testSystemProperties() throws Throwable {
+        System.setProperty("tracer.appName", "tracerhost1");
+        System.setProperty("tracer.sampleRate", "1");
+        System.setProperty("tracer.zipkinUrl", "http://zipkinUrl");
+        TemporaryFolder tmpFolder = new TemporaryFolder();
+        tmpFolder.create();
+        TestTracingHost h = null;
+        try {
+            h = launchService(tmpFolder);
+            assertTrue(h.getTracer().getServiceTracer().getClosableSpans().size() > 0);
+            assertTrue(h.getTracer().getServiceTracer().getOpenedSpans().size() > 0);
+        } finally {
+            assertNotNull(h);
+            h.stop();
+            tmpFolder.delete();
+        }
+
+    }
+
+    @Test
+    public void testSystemPropertiesZeroSampling() throws Throwable {
+        System.setProperty("tracer.appName", "tracerhost2");
+        System.setProperty("tracer.sampleRate", "0");
+        System.setProperty("tracer.zipkinUrl", "http://zipkinUrl");
+        TemporaryFolder tmpFolder = new TemporaryFolder();
+        tmpFolder.create();
+        TestTracingHost h = null;
+        try {
+            h = launchService(tmpFolder);
+            assertTrue(h.getTracer().getServiceTracer().getClosableSpans().size() == 0);
+            assertTrue(h.getTracer().getServiceTracer().getOpenedSpans().size() == 0);
+        } finally {
+            assertNotNull(h);
+            h.stop();
+            tmpFolder.delete();
+        }
+
+    }
+}


### PR DESCRIPTION
### Reference to Issue / Blueprint
https://www.pivotaltracker.com/story/show/131436049

### Description of changes
Adding a simpler distributed tracing library to push traces to Zipkin.

### Summary of testing
Written 3 tests into the library. Also, tried it manually with yet another Xenon-Service which intercepts the calls to Xenon, and uses this library to set the ContextId as a Json blob (before submitting the operation to Xenon). Could observe that contextId in Xenon operation-index was capturing the Json holding the trace fields. This will allow us to extend the library to submit directly to Xenon operation-index, but that will come later.

### Summary of results
Tests passes

### Reviewers
@georgechrysanthakopoulos 