### PR TITLE
Dispatch HTTP responses on the ServiceHost executor.

### DIFF
--- a/xenon-common/src/main/java/com/vmware/xenon/common/ServiceClient.java
+++ b/xenon-common/src/main/java/com/vmware/xenon/common/ServiceClient.java
@@ -44,6 +44,9 @@ public interface ServiceClient extends ServiceRequestSender {
     public static final String PROPERTY_NAME_DEFAULT_CONNECTION_LIMIT_PER_TAG =
             Utils.PROPERTY_NAME_PREFIX + "ServiceClient.DEFAULT_CONNECTION_LIMIT_PER_TAG";
 
+    public static final String PROPERTY_NAME_ENABLE_DIRECT_COMPLETIONS =
+            Utils.PROPERTY_NAME_PREFIX + "ServiceClient.ENABLE_DIRECT_COMPLETIONS";
+
     public static final int MAX_BINARY_SERIALIZED_BODY_LIMIT = Integer.getInteger(
             PROPERTY_NAME_MAX_BINARY_SERIALIZED_BODY_LIMIT, 1024 * 1024);
 
@@ -58,6 +61,9 @@ public interface ServiceClient extends ServiceRequestSender {
 
     public static final int DEFAULT_PENDING_REQUEST_QUEUE_LIMIT = Integer.getInteger(
             PROPERTY_NAME_PENDING_REQUEST_QUEUE_LIMIT, 100000);
+
+    public static final boolean ENABLE_DIRECT_COMPLETIONS = Boolean.getBoolean(
+            PROPERTY_NAME_ENABLE_DIRECT_COMPLETIONS);
 
     /**
      * Connection tag used by node group service for peer to peer random probing and liveness checks

--- a/xenon-common/src/main/java/com/vmware/xenon/common/http/netty/NettyHttpServiceClient.java
+++ b/xenon-common/src/main/java/com/vmware/xenon/common/http/netty/NettyHttpServiceClient.java
@@ -590,7 +590,18 @@ public class NettyHttpServiceClient implements ServiceClient {
                 // After request is sent control is transferred to the
                 // NettyHttpServerResponseHandler. The response handler will nest completions
                 // and call complete() when response is received, which will invoke this completion
-                op.complete();
+                ExecutorService executorService;
+                if (ENABLE_DIRECT_COMPLETIONS) {
+                    executorService = null;
+                } else {
+                    executorService = this.host != null ? this.host.getExecutor() : this.executor;
+                }
+
+                if (executorService != null) {
+                    executorService.execute(op::complete);
+                } else {
+                    op.complete();
+                }
             });
 
             op.toggleOption(OperationOption.SOCKET_ACTIVE, true);


### PR DESCRIPTION
This change modifies the HTTP service client to perform HTTP
response completions on the executor service associated with the
ServiceHost or the executor service, rather than calling the
completion directly from the Netty event loop thread. A JVM flag
allows Xenon consumers to restore the original behavior.

Calling completions directly from the Netty thread is more
performant -- throughput is higher and latency is lower -- but this
design also allows callers to clog up the event loop by making
blocking calls from within completion handlers on this thread,
leading to hard-to-diagnose error conditions and performance
degradation.

Change-Id: I5f6b2897cad4efd29ad031b39e78f33524a91650

## Description

## Tracker link
